### PR TITLE
Allow cross-compilation by using CARGO_CFG_TARGET_OS instead of conditional compilation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,39 +1,42 @@
+use std::env;
+
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 fn main() {
-    cc::Build::new()
-        .file("c_code/triangle.c")
-        .file("c_code/tricall_report.c")
-        .file("c_code/interface_triangle.c")
-        .flag("-Wno-sign-compare")
-        .flag("-Wno-unused-parameter")
-        .flag("-Wno-unused-but-set-variable")
-        .flag("-Wno-maybe-uninitialized")
-        .flag("-Wno-old-style-definition")
-        .compile("c_code_interface_triangle");
-    cc::Build::new()
-        .cpp(true)
-        .file("c_code/predicates.cxx")
-        .file("c_code/tetgen.cxx")
-        .file("c_code/interface_tetgen.cpp")
-        .flag("-Wno-int-to-pointer-cast")
-        .flag("-Wno-unused-parameter")
-        .flag("-Wno-unused-but-set-variable")
-        .flag("-Wno-maybe-uninitialized")
-        .compile("c_code_interface_tetgen");
-}
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
 
-#[cfg(target_os = "windows")]
-fn main() {
-    cc::Build::new()
-        .file("c_code/triangle.c")
-        .file("c_code/tricall_report.c")
-        .file("c_code/interface_triangle.c")
-        .define("NO_TIMER", None)
-        .compile("c_code_interface_triangle");
-    cc::Build::new()
-        .cpp(true)
-        .file("c_code/predicates.cxx")
-        .file("c_code/tetgen.cxx")
-        .file("c_code/interface_tetgen.cpp")
-        .compile("c_code_interface_tetgen");
+    if (target_os == "linux") | (target_os == "macos") {
+        cc::Build::new()
+            .file("c_code/triangle.c")
+            .file("c_code/tricall_report.c")
+            .file("c_code/interface_triangle.c")
+            .flag("-Wno-sign-compare")
+            .flag("-Wno-unused-parameter")
+            .flag("-Wno-unused-but-set-variable")
+            .flag("-Wno-maybe-uninitialized")
+            .flag("-Wno-old-style-definition")
+            .compile("c_code_interface_triangle");
+        cc::Build::new()
+            .cpp(true)
+            .file("c_code/predicates.cxx")
+            .file("c_code/tetgen.cxx")
+            .file("c_code/interface_tetgen.cpp")
+            .flag("-Wno-int-to-pointer-cast")
+            .flag("-Wno-unused-parameter")
+            .flag("-Wno-unused-but-set-variable")
+            .flag("-Wno-maybe-uninitialized")
+            .compile("c_code_interface_tetgen");
+    } else if target_os == "windows" {
+        cc::Build::new()
+            .file("c_code/triangle.c")
+            .file("c_code/tricall_report.c")
+            .file("c_code/interface_triangle.c")
+            .define("NO_TIMER", None)
+            .compile("c_code_interface_triangle");
+        cc::Build::new()
+            .cpp(true)
+            .file("c_code/predicates.cxx")
+            .file("c_code/tetgen.cxx")
+            .file("c_code/interface_tetgen.cpp")
+            .compile("c_code_interface_tetgen");
+    }
 }


### PR DESCRIPTION
[Apparently](https://kazlauskas.me/entries/writing-proper-buildrs-scripts), `target_os` from `cfg` macros actually refers to the _host_ OS rather than the _target_ OS (contrary to what the name suggests...), so when doing cross compilation that does not work. See also e.g. [this thread](https://users.rust-lang.org/t/compile-for-windows-from-linux-when-have-build-rs/76858/2). Note that during normal compilation the host OS is the target OS so this is not an issue.

I have actually experienced it first hand while trying to build `tritet` for `x86_64-pc-windows-msvc` from a linux machine: it won't compile because `NO_TIMER` is not defined, and so the Windows incompatible statements are included at compilation. Relying on the [Cargo environment variables](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts) however does the expected thing.